### PR TITLE
fix: restore script injection for Jellyfin 10.11.6+

### DIFF
--- a/docs/operations/installation.md
+++ b/docs/operations/installation.md
@@ -47,7 +47,7 @@ Install [jellyfin-plugin-file-transformation](https://github.com/IAmParadox27/je
 3. Scroll to **Custom HTML** (Branding section)
 4. Add this line to the "Custom HTML body" field:
    ```html
-   <script src="/OpenWatchParty/ClientScript"></script>
+   <script src="../OpenWatchParty/ClientScript"></script>
    ```
 5. Click **Save**
 6. Hard refresh your browser (Ctrl+F5)

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -33,9 +33,9 @@ nav_order: 5
 1. **Check Custom HTML configuration**
    - Go to Dashboard > General > Branding
    - Verify this line is in "Custom HTML body":
-     ```html
-     <script src="/OpenWatchParty/ClientScript"></script>
-     ```
+       ```html
+       <script src="../OpenWatchParty/ClientScript"></script>
+       ```
 
 2. **Hard refresh the browser**
    - Press Ctrl+F5 (Windows/Linux) or Cmd+Shift+R (Mac)

--- a/infra/docker/dev/docker-compose.yml
+++ b/infra/docker/dev/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       start_period: 5s
 
   jellyfin-dev:
-    image: jellyfin/jellyfin:10.11.3
+    image: jellyfin/jellyfin:10.11.6
     container_name: jellyfin-dev
     environment:
       - PUID=${UID:-1000}

--- a/infra/just/common.just
+++ b/infra/just/common.just
@@ -41,8 +41,8 @@ RESET  := '\033[0m'
 
 # -- File Transformation plugin ------------------------------------------------
 
-ft_version := "2.5.3.0"
-ft_abi     := "10.11.3"
+ft_version := "2.5.5.0"
+ft_abi     := "10.11.6"
 ft_url     := "https://github.com/IAmParadox27/jellyfin-plugin-file-transformation/releases/download/" + ft_version + "/Release-" + ft_abi + ".zip"
 ft_dir     := "infra/docker/dev/config/plugins/FileTransformation"
 ft_marker  := ft_dir + "/.version"

--- a/src/clients/jellyfin-web/app/lifecycle.js
+++ b/src/clients/jellyfin-web/app/lifecycle.js
@@ -69,6 +69,10 @@
           }
         }
       }
+
+      // Jellyfin is an SPA; header DOM is frequently replaced during navigation.
+      // Keep a global launcher button present even when no video OSD exists.
+      ui.injectGlobalButton();
     }, UI_CHECK_MS);
     state.intervals.home = setInterval(() => {
       if (document.visibilityState === 'visible' && utils.isHomeView()) {

--- a/src/clients/jellyfin-web/plugin.js
+++ b/src/clients/jellyfin-web/plugin.js
@@ -5,15 +5,20 @@
 
   const currentScript = document.currentScript;
   let cacheBust = '';
+  let basePrefix = '';
   if (currentScript && currentScript.src) {
     try {
       const url = new URL(currentScript.src, window.location.href);
       cacheBust = url.searchParams.get('v') || '';
+      const suffix = '/OpenWatchParty/ClientScript';
+      if (url.pathname.endsWith(suffix)) {
+        basePrefix = url.pathname.slice(0, -suffix.length);
+      }
     } catch (err) {}
   }
   if (!cacheBust) cacheBust = String(Date.now());
 
-  const base = '/web/plugins/openwatchparty';
+  const base = `${basePrefix}/OpenWatchParty/Client`;
 
   const SCRIPT_TIMEOUT_MS = 10000;  // 10 seconds timeout per script
 

--- a/src/clients/jellyfin-web/ui/render.js
+++ b/src/clients/jellyfin-web/ui/render.js
@@ -4,6 +4,18 @@
   const state = OWP.state;
   const utils = OWP.utils;
   const { PANEL_ID, BTN_ID, DEFAULT_WS_URL } = OWP.constants;
+  const GLOBAL_BTN_ID = 'owp-global-btn';
+
+  const togglePanel = (e) => {
+    if (e) {
+      e.stopPropagation();
+      e.preventDefault();
+    }
+    const panel = document.getElementById(PANEL_ID);
+    if (!panel) return;
+    panel.classList.toggle('hide');
+    if (!panel.classList.contains('hide')) render(true);
+  };
 
   const renderLobby = (panel) => {
     panel.innerHTML = `
@@ -108,12 +120,7 @@
     btn.className = 'paper-icon-button-light btnWatchParty autoSize';
     btn.title = 'Watch Party';
     btn.innerHTML = '<span class="material-icons groups" aria-hidden="true"></span>';
-    btn.onclick = (e) => {
-      e.stopPropagation(); e.preventDefault();
-      const panel = document.getElementById(PANEL_ID);
-      panel.classList.toggle('hide');
-      if (!panel.classList.contains('hide')) render(true);
-    };
+    btn.onclick = togglePanel;
     const favBtn = videoOsd.querySelector('[title="Add to favorites"], [title="Remove from favorites"]');
     if (favBtn) {
       favBtn.insertAdjacentElement('beforebegin', btn);
@@ -122,5 +129,22 @@
     }
   };
 
-  Object.assign(ui, { render, injectOsdButton });
+  const injectGlobalButton = () => {
+    if (document.getElementById(GLOBAL_BTN_ID)) return;
+    const headerRight = document.querySelector('.headerRight') || document.querySelector('.skinHeader .headerRight');
+    if (!headerRight) return;
+
+    const btn = document.createElement('button');
+    btn.id = GLOBAL_BTN_ID;
+    btn.className = 'paper-icon-button-light owp-global-btn';
+    btn.type = 'button';
+    btn.title = 'OpenWatchParty';
+    btn.setAttribute('aria-label', 'OpenWatchParty');
+    btn.innerHTML = '<span class="material-icons groups" aria-hidden="true"></span>';
+    btn.onclick = togglePanel;
+
+    headerRight.prepend(btn);
+  };
+
+  Object.assign(ui, { render, injectOsdButton, injectGlobalButton });
 })();

--- a/src/clients/jellyfin-web/ui/styles.js
+++ b/src/clients/jellyfin-web/ui/styles.js
@@ -68,6 +68,15 @@
     #owp-chat-send { padding: 8px 12px; border-radius: 6px; border: none; background: #1565c0; color: #fff; cursor: pointer; font-size: 12px; }
     #owp-chat-send:hover { background: #1976d2; }
     .owp-chat-badge { display: none; background: #d32f2f; color: #fff; font-size: 10px; padding: 2px 5px; border-radius: 10px; margin-left: 4px; }
+    .owp-global-btn {
+      margin-right: 10px;
+      color: #fff;
+      opacity: 0.92;
+    }
+    .owp-global-btn:hover {
+      opacity: 1;
+      color: #69f0ae;
+    }
     /* Toast styles */
     .owp-toast-container {
       position: fixed; top: 70px; right: 20px; z-index: 30000;

--- a/src/plugins/jellyfin/OpenWatchParty.Tests/FileTransformationIntegrationTests.cs
+++ b/src/plugins/jellyfin/OpenWatchParty.Tests/FileTransformationIntegrationTests.cs
@@ -4,7 +4,7 @@ namespace OpenWatchParty.Plugin.Tests;
 
 public class FileTransformationIntegrationTests
 {
-    private const string ScriptTag = "<script src=\"/OpenWatchParty/ClientScript\" defer></script>";
+    private const string ScriptTag = "<script src=\"../OpenWatchParty/ClientScript\" defer></script>";
 
     private class FakePayload
     {
@@ -13,6 +13,71 @@ public class FileTransformationIntegrationTests
 
     private static object MakePayload(string? contents) => new FakePayload { contents = contents };
 
+    // -- InjectScript (core logic, used by both FT callback and direct file injection) --
+
+    [Fact]
+    public void InjectScript_InjectsBeforeBodyClose()
+    {
+        var html = "<html><head></head><body><h1>Jellyfin</h1></body></html>";
+        var result = FileTransformationIntegration.InjectScript(html);
+
+        Assert.Contains(ScriptTag, result);
+        Assert.True(result.IndexOf(ScriptTag) < result.LastIndexOf("</body>"));
+    }
+
+    [Fact]
+    public void InjectScript_InjectsBeforeHeadClose_WhenNoBody()
+    {
+        var html = "<html><head><title>Jellyfin</title></head><div>no body tag</div></html>";
+        var result = FileTransformationIntegration.InjectScript(html);
+
+        Assert.Contains(ScriptTag, result);
+        Assert.True(result.IndexOf(ScriptTag) < result.LastIndexOf("</head>"));
+    }
+
+    [Fact]
+    public void InjectScript_SkipsInjection_WhenAlreadyPresent()
+    {
+        var html = $"<html><body>{ScriptTag}</body></html>";
+        var result = FileTransformationIntegration.InjectScript(html);
+
+        Assert.Equal(html, result);
+    }
+
+    [Fact]
+    public void InjectScript_SkipsInjection_WhenAbsolutePathPresent()
+    {
+        var html = "<html><body><script src=\"/OpenWatchParty/ClientScript\"></script></body></html>";
+        var result = FileTransformationIntegration.InjectScript(html);
+
+        Assert.Equal(html, result);
+    }
+
+    [Fact]
+    public void InjectScript_ReturnsEmpty_WhenNull()
+    {
+        var result = FileTransformationIntegration.InjectScript(null!);
+        Assert.Equal(string.Empty, result);
+    }
+
+    [Fact]
+    public void InjectScript_ReturnsEmpty_WhenEmpty()
+    {
+        var result = FileTransformationIntegration.InjectScript(string.Empty);
+        Assert.Equal(string.Empty, result);
+    }
+
+    [Fact]
+    public void InjectScript_ReturnsUnchanged_WhenNoBodyOrHead()
+    {
+        var html = "<html><div>no head or body</div></html>";
+        var result = FileTransformationIntegration.InjectScript(html);
+
+        Assert.Equal(html, result);
+    }
+
+    // -- TransformIndexHtml (FT callback, extracts contents from payload) --
+
     [Fact]
     public void TransformIndexHtml_InjectsScript_WhenNotPresent()
     {
@@ -20,7 +85,6 @@ public class FileTransformationIntegrationTests
         var result = FileTransformationIntegration.TransformIndexHtml(MakePayload(html));
 
         Assert.Contains(ScriptTag, result);
-        Assert.Contains("</body>", result);
         Assert.True(result.IndexOf(ScriptTag) < result.LastIndexOf("</body>"));
     }
 

--- a/src/plugins/jellyfin/OpenWatchParty.Tests/OpenWatchParty.Tests.csproj
+++ b/src/plugins/jellyfin/OpenWatchParty.Tests/OpenWatchParty.Tests.csproj
@@ -21,8 +21,8 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <!-- Jellyfin dependencies for testing -->
-    <PackageReference Include="Jellyfin.Model" Version="10.11.5" />
-    <PackageReference Include="Jellyfin.Controller" Version="10.11.5" />
+    <PackageReference Include="Jellyfin.Model" Version="10.11.6" />
+    <PackageReference Include="Jellyfin.Controller" Version="10.11.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/plugins/jellyfin/OpenWatchParty/Controllers/OpenWatchPartyController.cs
+++ b/src/plugins/jellyfin/OpenWatchParty/Controllers/OpenWatchPartyController.cs
@@ -28,6 +28,7 @@ public class OpenWatchPartyController : ControllerBase
 
     // Cache for embedded script content using Lazy<T> for thread-safe initialization (fixes audit 4.5.1)
     private static readonly Lazy<(string Content, string ETag)> _scriptCache = new(LoadScriptFromResource, LazyThreadSafetyMode.ExecutionAndPublication);
+    private static readonly ConcurrentDictionary<string, (string Content, string ETag)> _clientModuleCache = new(StringComparer.OrdinalIgnoreCase);
 
     // P-CS02 fix: Cache JWT signing credentials and handler to avoid repeated allocations
     private static SigningCredentials? _cachedSigningCredentials;
@@ -86,6 +87,68 @@ public class OpenWatchPartyController : ControllerBase
         Response.Headers["ETag"] = etag;
 
         return Content(content, "text/javascript");
+    }
+
+    /// <summary>
+    /// Returns an OpenWatchParty client module JavaScript file from embedded resources.
+    /// This avoids relying on Jellyfin's /web/plugins static path.
+    /// </summary>
+    /// <param name="path">Relative module path, e.g. "state.js" or "ui/render.js".</param>
+    /// <returns>The JavaScript module content.</returns>
+    [HttpGet("Client/{*path}")]
+    [Produces("text/javascript")]
+    public ActionResult GetClientModule([FromRoute] string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return NotFound();
+        }
+
+        var normalizedPath = path.Replace('\\', '/').TrimStart('/');
+        if (normalizedPath.Contains("..", StringComparison.Ordinal) || !normalizedPath.EndsWith(".js", StringComparison.OrdinalIgnoreCase))
+        {
+            return NotFound();
+        }
+
+        try
+        {
+            var (content, etag) = _clientModuleCache.GetOrAdd(normalizedPath, LoadClientModuleFromResource);
+
+            var requestETag = Request.Headers["If-None-Match"].FirstOrDefault();
+            if (!string.IsNullOrEmpty(requestETag) && requestETag == etag)
+            {
+                return StatusCode(304);
+            }
+
+            Response.Headers["Cache-Control"] = "public, max-age=3600";
+            Response.Headers["ETag"] = etag;
+
+            return Content(content, "text/javascript");
+        }
+        catch (FileNotFoundException)
+        {
+            return NotFound();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to serve embedded client module '{Path}'", normalizedPath);
+            return StatusCode(500);
+        }
+    }
+
+    private static (string Content, string ETag) LoadClientModuleFromResource(string normalizedPath)
+    {
+        var assembly = typeof(OpenWatchPartyController).Assembly;
+        var resourceName = "OpenWatchParty.Plugin.Web." + normalizedPath.Replace('/', '.');
+
+        using var stream = assembly.GetManifestResourceStream(resourceName)
+            ?? throw new FileNotFoundException($"Embedded resource '{resourceName}' not found");
+
+        using var reader = new StreamReader(stream);
+        var content = reader.ReadToEnd();
+        var hash = System.Security.Cryptography.SHA256.HashData(Encoding.UTF8.GetBytes(content));
+        var etag = $"\"{Convert.ToBase64String(hash)[..16]}\"";
+        return (content, etag);
     }
 
     /// <summary>

--- a/src/plugins/jellyfin/OpenWatchParty/FileTransformationIntegration.cs
+++ b/src/plugins/jellyfin/OpenWatchParty/FileTransformationIntegration.cs
@@ -7,12 +7,14 @@ using Newtonsoft.Json.Linq;
 namespace OpenWatchParty.Plugin;
 
 /// <summary>
-/// Scheduled task that registers an index.html transformation with the
-/// jellyfin-plugin-file-transformation plugin (if installed) to automatically
-/// inject the OpenWatchParty client script.
+/// Scheduled task that injects the OpenWatchParty client script into index.html.
+/// First attempts to register with the File Transformation plugin (if installed).
+/// Falls back to direct injection into the physical index.html file.
 /// </summary>
 public class FileTransformationIntegration : IScheduledTask
 {
+    private const string ClientScriptPath = "../OpenWatchParty/ClientScript";
+    private const string ScriptTag = $"<script src=\"{ClientScriptPath}\" defer></script>";
     private readonly ILogger<FileTransformationIntegration> _logger;
 
     public string Name => "OpenWatchParty File Transformation Registration";
@@ -33,10 +35,28 @@ public class FileTransformationIntegration : IScheduledTask
         };
     }
 
-    public Task ExecuteAsync(IProgress<double> progress, CancellationToken cancellationToken)
+    public async Task ExecuteAsync(IProgress<double> progress, CancellationToken cancellationToken)
     {
         progress.Report(0);
 
+        if (TryRegisterFileTransformation())
+        {
+            progress.Report(100);
+            return;
+        }
+
+        // File Transformation unavailable — inject directly into the physical file
+        await InjectIntoIndexHtmlFileAsync(cancellationToken).ConfigureAwait(false);
+
+        progress.Report(100);
+    }
+
+    /// <summary>
+    /// Attempts to register with the File Transformation plugin via reflection.
+    /// Returns true if registration succeeded.
+    /// </summary>
+    private bool TryRegisterFileTransformation()
+    {
         try
         {
             var ftAssembly = AssemblyLoadContext.All
@@ -45,10 +65,7 @@ public class FileTransformationIntegration : IScheduledTask
 
             if (ftAssembly == null)
             {
-                _logger.LogInformation("[OpenWatchParty] File Transformation plugin not found. "
-                    + "Script injection will not be automatic — use Custom HTML instead.");
-                progress.Report(100);
-                return Task.CompletedTask;
+                return false;
             }
 
             var pluginInterface = ftAssembly.GetType("Jellyfin.Plugin.FileTransformation.PluginInterface");
@@ -56,8 +73,7 @@ public class FileTransformationIntegration : IScheduledTask
             {
                 _logger.LogWarning("[OpenWatchParty] File Transformation plugin found but PluginInterface type not available. "
                     + "The installed version may be incompatible.");
-                progress.Report(100);
-                return Task.CompletedTask;
+                return false;
             }
 
             var registerMethod = pluginInterface.GetMethod("RegisterTransformation", BindingFlags.Public | BindingFlags.Static);
@@ -65,14 +81,13 @@ public class FileTransformationIntegration : IScheduledTask
             {
                 _logger.LogWarning("[OpenWatchParty] File Transformation plugin found but RegisterTransformation method not available. "
                     + "The installed version may be incompatible.");
-                progress.Report(100);
-                return Task.CompletedTask;
+                return false;
             }
 
             var payload = new JObject
             {
-                ["id"] = Plugin.PluginGuid,
-                ["fileNamePattern"] = "index.html",
+                ["id"] = Guid.Parse(Plugin.PluginGuid),
+                ["fileNamePattern"] = @"^index\.html$",
                 ["callbackAssembly"] = typeof(FileTransformationIntegration).Assembly.FullName,
                 ["callbackClass"] = typeof(FileTransformationIntegration).FullName,
                 ["callbackMethod"] = nameof(TransformIndexHtml)
@@ -81,15 +96,89 @@ public class FileTransformationIntegration : IScheduledTask
             registerMethod.Invoke(null, new object?[] { payload });
 
             _logger.LogInformation("[OpenWatchParty] Registered index.html transformation with File Transformation plugin.");
+            return true;
         }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "[OpenWatchParty] Failed to register with File Transformation plugin. "
+                + "Falling back to direct index.html injection.");
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Directly injects the script tag into the physical index.html file
+    /// in Jellyfin's web directory. This is the fallback when File Transformation
+    /// is unavailable (e.g., after an in-process restart on Jellyfin 10.11.6+).
+    /// </summary>
+    private async Task InjectIntoIndexHtmlFileAsync(CancellationToken cancellationToken)
+    {
+        var webDir = Environment.GetEnvironmentVariable("JELLYFIN_WEB_DIR");
+        if (string.IsNullOrEmpty(webDir))
+        {
+            _logger.LogInformation("[OpenWatchParty] File Transformation plugin not available and JELLYFIN_WEB_DIR not set. "
                 + "Script injection will not be automatic — use Custom HTML instead.");
+            return;
         }
 
-        progress.Report(100);
-        return Task.CompletedTask;
+        var indexPath = Path.Combine(webDir, "index.html");
+        if (!File.Exists(indexPath))
+        {
+            _logger.LogWarning("[OpenWatchParty] index.html not found at '{Path}'. "
+                + "Script injection will not be automatic — use Custom HTML instead.", indexPath);
+            return;
+        }
+
+        try
+        {
+            var html = await File.ReadAllTextAsync(indexPath, cancellationToken).ConfigureAwait(false);
+            var modified = InjectScript(html);
+
+            if (modified == html)
+            {
+                _logger.LogInformation("[OpenWatchParty] Client script already present in {Path}.", indexPath);
+                return;
+            }
+
+            await File.WriteAllTextAsync(indexPath, modified, cancellationToken).ConfigureAwait(false);
+            _logger.LogInformation("[OpenWatchParty] Injected client script into {Path} (direct fallback).", indexPath);
+        }
+        catch (UnauthorizedAccessException)
+        {
+            _logger.LogInformation("[OpenWatchParty] No write permission to {Path}. "
+                + "Using controller-level index.html interception instead.", indexPath);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "[OpenWatchParty] Failed to inject script into {Path}. "
+                + "Using controller-level index.html interception instead.", indexPath);
+        }
+    }
+
+    /// <summary>
+    /// Core injection logic: inserts the script tag before &lt;/body&gt; or &lt;/head&gt;
+    /// if the script is not already present.
+    /// </summary>
+    internal static string InjectScript(string contents)
+    {
+        if (string.IsNullOrEmpty(contents) || contents.Contains("OpenWatchParty/ClientScript", StringComparison.OrdinalIgnoreCase))
+        {
+            return contents ?? string.Empty;
+        }
+
+        var bodyEndIndex = contents.LastIndexOf("</body>", StringComparison.OrdinalIgnoreCase);
+        if (bodyEndIndex >= 0)
+        {
+            return contents.Insert(bodyEndIndex, $"    {ScriptTag}\n");
+        }
+
+        var headEndIndex = contents.LastIndexOf("</head>", StringComparison.OrdinalIgnoreCase);
+        if (headEndIndex >= 0)
+        {
+            return contents.Insert(headEndIndex, $"    {ScriptTag}\n");
+        }
+
+        return contents;
     }
 
     /// <summary>
@@ -100,22 +189,26 @@ public class FileTransformationIntegration : IScheduledTask
     {
         var contents = payload is JObject jobj
             ? jobj["contents"]?.ToString()
+                ?? jobj["Contents"]?.ToString()
+                ?? jobj["content"]?.ToString()
+                ?? jobj["Content"]?.ToString()
             : payload?.GetType()
                 .GetProperty("contents")?
                 .GetValue(payload)?
+                .ToString()
+                ?? payload?.GetType()
+                    .GetProperty("Contents")?
+                    .GetValue(payload)?
+                    .ToString()
+                ?? payload?.GetType()
+                    .GetProperty("content")?
+                    .GetValue(payload)?
+                    .ToString()
+                ?? payload?.GetType()
+                    .GetProperty("Content")?
+                .GetValue(payload)?
                 .ToString();
 
-        if (string.IsNullOrEmpty(contents) || contents.Contains("/OpenWatchParty/ClientScript"))
-        {
-            return contents ?? string.Empty;
-        }
-
-        var bodyEndIndex = contents.LastIndexOf("</body>", StringComparison.OrdinalIgnoreCase);
-        if (bodyEndIndex >= 0)
-        {
-            return contents.Insert(bodyEndIndex, "    <script src=\"/OpenWatchParty/ClientScript\" defer></script>\n");
-        }
-
-        return contents;
+        return InjectScript(contents ?? string.Empty);
     }
 }

--- a/src/plugins/jellyfin/OpenWatchParty/OpenWatchPartyPlugin.csproj
+++ b/src/plugins/jellyfin/OpenWatchParty/OpenWatchPartyPlugin.csproj
@@ -15,12 +15,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="OpenWatchParty.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jellyfin.Controller" Version="10.11.3" ExcludeAssets="runtime" />
-    <PackageReference Include="Jellyfin.Model" Version="10.11.3" ExcludeAssets="runtime" />
+    <PackageReference Include="Jellyfin.Controller" Version="10.11.6" ExcludeAssets="runtime" />
+    <PackageReference Include="Jellyfin.Model" Version="10.11.6" ExcludeAssets="runtime" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" ExcludeAssets="runtime" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.35.0" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.35.0" />
@@ -28,6 +32,6 @@
 
   <ItemGroup>
     <EmbeddedResource Include="Web\configPage.html" />
-    <EmbeddedResource Include="Web\plugin.js" />
+    <EmbeddedResource Include="Web\**\*.js" />
   </ItemGroup>
 </Project>

--- a/src/plugins/jellyfin/OpenWatchParty/ScriptInjectionMiddleware.cs
+++ b/src/plugins/jellyfin/OpenWatchParty/ScriptInjectionMiddleware.cs
@@ -1,0 +1,106 @@
+using System.Text;
+using MediaBrowser.Controller;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace OpenWatchParty.Plugin;
+
+/// <summary>
+/// ASP.NET Core middleware that intercepts requests for the Jellyfin web client
+/// index.html and injects the OpenWatchParty client script tag.
+///
+/// Registered via IStartupFilter so it runs BEFORE Jellyfin's static file
+/// middleware, which would otherwise serve the unmodified index.html.
+/// </summary>
+public class ScriptInjectionMiddleware
+{
+    private readonly RequestDelegate _next;
+    private static readonly Lazy<(byte[] Content, string ETag)?> _cache =
+        new(LoadContent, LazyThreadSafetyMode.ExecutionAndPublication);
+
+    public ScriptInjectionMiddleware(RequestDelegate next)
+    {
+        _next = next;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        var path = context.Request.Path.Value?.TrimEnd('/');
+        if (path is "/web" or "/web/index.html")
+        {
+            var cached = _cache.Value;
+            if (cached.HasValue)
+            {
+                var (content, etag) = cached.Value;
+
+                var requestETag = context.Request.Headers.IfNoneMatch.FirstOrDefault();
+                if (!string.IsNullOrEmpty(requestETag) && requestETag == etag)
+                {
+                    context.Response.StatusCode = 304;
+                    return;
+                }
+
+                context.Response.ContentType = "text/html; charset=utf-8";
+                context.Response.Headers.CacheControl = "no-cache";
+                context.Response.Headers.ETag = etag;
+                context.Response.ContentLength = content.Length;
+                await context.Response.Body.WriteAsync(content);
+                return;
+            }
+        }
+
+        await _next(context);
+    }
+
+    private static (byte[] Content, string ETag)? LoadContent()
+    {
+        try
+        {
+            var webDir = Environment.GetEnvironmentVariable("JELLYFIN_WEB_DIR")
+                ?? "/usr/share/jellyfin/web";
+            var indexPath = Path.Combine(webDir, "index.html");
+            var html = File.ReadAllText(indexPath);
+            var modified = FileTransformationIntegration.InjectScript(html);
+
+            var bytes = Encoding.UTF8.GetBytes(modified);
+            var hash = System.Security.Cryptography.SHA256.HashData(bytes);
+            var etag = $"\"{Convert.ToBase64String(hash)[..16]}\"";
+            return (bytes, etag);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}
+
+/// <summary>
+/// Startup filter that registers the script injection middleware at the very
+/// beginning of the pipeline, before static files middleware.
+/// </summary>
+public class ScriptInjectionStartupFilter : IStartupFilter
+{
+    public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next)
+    {
+        return app =>
+        {
+            app.UseMiddleware<ScriptInjectionMiddleware>();
+            next(app);
+        };
+    }
+}
+
+/// <summary>
+/// Registers plugin services with Jellyfin's DI container.
+/// This is called during ConfigureServices, before the middleware pipeline is built.
+/// </summary>
+public class ServiceRegistrator : MediaBrowser.Controller.Plugins.IPluginServiceRegistrator
+{
+    /// <inheritdoc />
+    public void RegisterServices(IServiceCollection serviceCollection, IServerApplicationHost applicationHost)
+    {
+        serviceCollection.AddSingleton<IStartupFilter, ScriptInjectionStartupFilter>();
+    }
+}


### PR DESCRIPTION
Jellyfin 10.11.6+ removed static plugin file serving and breaks the File Transformation plugin's DI services after in-process restarts. This caused the OpenWatchParty button to disappear entirely.

Three-tier script injection fallback:
1. File Transformation plugin registration (if available)
2. Direct index.html file write (if writable)
3. ASP.NET middleware via IStartupFilter (always works)

The middleware approach registers before Jellyfin's static file middleware, intercepting /web/ requests to inject the script tag. This works even in read-only Docker containers.

Other changes:
- Serve all JS modules from embedded resources via /OpenWatchParty/Client/
- Add global header button for panel access outside video player
- Update Jellyfin package targets to 10.11.6
- Update File Transformation plugin to 2.5.5.0